### PR TITLE
fix table naming for array columns

### DIFF
--- a/lib/promiscuous_black_hole/embedded_message.rb
+++ b/lib/promiscuous_black_hole/embedded_message.rb
@@ -56,7 +56,7 @@ module Promiscuous::BlackHole
       end
 
       def self.from_value(key, value, parent_message)
-        message_payload = { 'types' =>["#{parent_message.base_type}$#{ key }"] }
+        message_payload = { 'types' =>["#{parent_message.table_name.singularize}$#{ key }"] }
         value.map do |element|
           custom_attrs = { 'attributes' => { key.singularize => element }, 'id' => BSON::ObjectId.new.to_s }
           EmbeddedMessage.new(message_payload.merge(custom_attrs), parent_message)

--- a/spec/integration/array_insertion_spec.rb
+++ b/spec/integration/array_insertion_spec.rb
@@ -82,4 +82,19 @@ describe Promiscuous::BlackHole do
       expect(extract_array('publisher_model', 'group')).to eq([Date.new(2015, 2, 10)])
     end
   end
+
+  it 'correctly handles complex table names' do
+    define_constant :'PublisherModel::Base' do
+      include Mongoid::Document
+      include Promiscuous::Publisher
+      field :groups
+      publish :groups
+    end
+
+    PublisherModel::Base.create!(:groups => ['2014-10-10', '2013-10-10', '2013-10-11'])
+
+    eventually do
+      expect(DB.table_exists?(:'publisher_model$groups')).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Array fields should use the same logic that other fields use. In an ideal world, this would be covered by a unit test, not an integration test, but reworking the testing strategy is way beyond the scope of this pull.