### PR TITLE
cache embeddings within an operation

### DIFF
--- a/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
+++ b/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
@@ -22,7 +22,7 @@ module Promiscuous::BlackHole
 
     def child_tables
       criteria = DB[:embeddings].where('parent_table = ?', @table_name)
-      @cached_embeddings[criteria.sql] ||= criteria.map(:child_table)
+      @cached_embeddings[criteria.sql.hash] ||= criteria.map(:child_table)
     end
 
     private

--- a/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
+++ b/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
@@ -1,14 +1,15 @@
 module Promiscuous::BlackHole
   class StaleEmbeddingsDestroyer
-    def initialize(table_name, parent_id)
+    def initialize(table_name, parent_id, cached_embeddings={})
       @table_name = table_name
       @parent_id  = parent_id
+      @cached_embeddings = cached_embeddings
     end
 
     def process
       child_tables.each do |child_table|
         child_ids_for(child_table).each do |id|
-          StaleEmbeddingsDestroyer.new(child_table, id).process
+          StaleEmbeddingsDestroyer.new(child_table, id, @cached_embeddings).process
         end
 
         criteria_for(child_table).delete
@@ -20,7 +21,8 @@ module Promiscuous::BlackHole
     end
 
     def child_tables
-      DB[:embeddings].where('parent_table = ?', @table_name).map(:child_table)
+      criteria = DB[:embeddings].where('parent_table = ?', @table_name)
+      @cached_embeddings[criteria.sql] ||= criteria.map(:child_table)
     end
 
     private


### PR DESCRIPTION
when recursively looking for embeddings, cache any queries that have already been tried

will cut down on all of these repeated queries per transaction:
<img width="1156" alt="transactions_-_normcore2_-_new_relic" src="https://cloud.githubusercontent.com/assets/1707408/9505261/6b8ddee0-4c0f-11e5-8c2c-57d823660e59.png">

