### PR TITLE
Bs fix embedding better

### DIFF
--- a/lib/promiscuous_black_hole/operation.rb
+++ b/lib/promiscuous_black_hole/operation.rb
@@ -5,8 +5,9 @@ require 'promiscuous_black_hole/table'
 
 module Promiscuous::BlackHole
   class Operation
-    def initialize(message)
+    def initialize(message, embedded: false)
       @message = message
+      @embedded = embedded
     end
 
     def self.process(message)
@@ -60,7 +61,7 @@ module Promiscuous::BlackHole
     end
 
     def persist_embedded_records
-      StaleEmbeddingsDestroyer.new(message.table_name, message.id).process
+      StaleEmbeddingsDestroyer.new(message.table_name, message.id).process unless @embedded
       embedded_operations.each(&:persist)
     end
 
@@ -73,7 +74,7 @@ module Promiscuous::BlackHole
     end
 
     def embedded_operations
-      @embedded_operations ||= message.embedded_messages.map { |em| Operation.new(em) }
+      @embedded_operations ||= message.embedded_messages.map { |em| Operation.new(em, embedded: true)}
     end
 
     def with_wrapped_error(&block)

--- a/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
+++ b/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
@@ -21,11 +21,14 @@ module Promiscuous::BlackHole
     end
 
     def child_tables
-      criteria = DB[:embeddings].where('parent_table = ?', @table_name)
-      @cached_embeddings[criteria.sql.hash] ||= criteria.map(:child_table)
+      @cached_embeddings[@table_name] ||= fetch_child_tables
     end
 
     private
+
+    def fetch_child_tables
+      DB[:embeddings].where('parent_table = ?', @table_name).map(:child_table)
+    end
 
     def criteria_for(table)
       DB[table].where('embedded_in_id = ?', @parent_id)

--- a/spec/performance/embedding_selects_spec.rb
+++ b/spec/performance/embedding_selects_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Promiscuous::BlackHole do
+  it 'caches embeddings within a message' do
+    $calls = 0
+
+    class Promiscuous::BlackHole::StaleEmbeddingsDestroyer
+      alias_method :orig_fetch_child_tables, :fetch_child_tables
+      def fetch_child_tables
+        $calls += 1
+        orig_fetch_child_tables
+      end
+    end
+
+    class PublisherModel
+      embeds_many :embedded_publishers
+      publish :embedded_publishers
+    end
+
+    define_constant :EmbeddedPublisher do
+      include Mongoid::Document
+      include Promiscuous::Publisher
+      embedded_in :publisher_model
+      embeds_one :more_embedded_publisher
+    end
+
+    define_constant :MoreEmbeddedPublisher do
+      include Mongoid::Document
+      include Promiscuous::Publisher
+      embedded_in :embedded_publisher
+    end
+
+
+    m = PublisherModel.create!(:embedded_publishers => 50.times.map do |child|
+        EmbeddedPublisher.new(:more_embedded_publisher => MoreEmbeddedPublisher.new)
+      end
+                          )
+
+    sleep 1
+
+    m.update_attributes(:embedded_publishers => [EmbeddedPublisher.new])
+    sleep 5
+    p $calls
+  end
+end

--- a/spec/performance/embedding_selects_spec.rb
+++ b/spec/performance/embedding_selects_spec.rb
@@ -31,10 +31,10 @@ describe Promiscuous::BlackHole do
     end
 
 
-    m = PublisherModel.create!(:embedded_publishers => 50.times.map do |child|
-        EmbeddedPublisher.new(:more_embedded_publisher => MoreEmbeddedPublisher.new)
-      end
-                          )
+    embedded_publishers = 50.times.map do |child|
+      EmbeddedPublisher.new(:more_embedded_publisher => MoreEmbeddedPublisher.new)
+    end
+    m = PublisherModel.create!(:embedded_publishers => embedded_publishers)
 
     sleep 1
 


### PR DESCRIPTION
After https://github.com/promiscuous-io/promiscuous_black_hole/pulls/6, I still noticed we were making too many calls to update embeddings. It turns out that if there are recursive embeddings, we were trying to remove embeddings recursively at every level of embedding. The perf spec went from 103 calls in the initial implementation (before https://github.com/promiscuous-io/promiscuous_black_hole/pulls/6) to 53 after that pull, to 3 in this implementation.