### PR TITLE
Read and write embeddings from public schema

### DIFF
--- a/lib/promiscuous_black_hole.rb
+++ b/lib/promiscuous_black_hole.rb
@@ -7,10 +7,12 @@ require 'sequel'
 require 'promiscuous_black_hole/config'
 require 'promiscuous_black_hole/db'
 require 'promiscuous_black_hole/unit_of_work'
+require 'promiscuous_black_hole/embeddings_table'
 
 module Promiscuous::BlackHole
   def self.start
     connect
+    EmbeddingsTable.ensure_exists
     cli = Promiscuous::CLI.new
     cli.options = { :action => :subscribe }
     cli.run

--- a/lib/promiscuous_black_hole/embeddings_table.rb
+++ b/lib/promiscuous_black_hole/embeddings_table.rb
@@ -1,0 +1,22 @@
+module Promiscuous::BlackHole
+  class EmbeddingsTable
+    def self.dataset
+      DB[:public__embeddings]
+    end
+
+    def self.ensure_exists
+      return if DB.table_exists?(:embeddings, :schema => :public)
+      Locker.new('embeddings').with_lock do
+        DB.create_table?(:public__embeddings) do
+          primary_key [:parent_table, :child_table], :name => :embeddings_pk
+          column :parent_table, 'varchar(255)'
+          column :child_table, 'varchar(255)'
+        end
+      end
+    end
+
+    def self.method_missing(*args, &block)
+      dataset.public_send(*args, &block)
+    end
+  end
+end

--- a/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
+++ b/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
@@ -27,7 +27,7 @@ module Promiscuous::BlackHole
     private
 
     def fetch_child_tables
-      DB[:embeddings].where('parent_table = ?', @table_name).map(:child_table)
+      EmbeddingsTable.where('parent_table = ?', @table_name).map(:child_table)
     end
 
     def criteria_for(table)

--- a/lib/promiscuous_black_hole/table.rb
+++ b/lib/promiscuous_black_hole/table.rb
@@ -33,11 +33,11 @@ module Promiscuous::BlackHole
         :child_table => table_name.to_s
       }
 
-      embedding = DB[:embeddings].where(attrs)
+      embedding = EmbeddingsTable.where(attrs)
 
       if embedding.first.nil?
         Locker.new('embeddings').with_lock do
-          DB[:embeddings].insert(attrs) if embedding.first.nil?
+          EmbeddingsTable.insert(attrs) if embedding.first.nil?
         end
       end
     end

--- a/spec/integration/schema_rotation_spec.rb
+++ b/spec/integration/schema_rotation_spec.rb
@@ -18,6 +18,19 @@ describe Promiscuous::BlackHole do
     end
   end
 
+  it 'reads and writes the embeddings table from the public schema' do
+    Promiscuous::BlackHole::Config.configure do |cfg|
+      cfg.schema_generator = -> { 'bonanza' }
+    end
+
+    PublisherModel.create!
+
+    eventually do
+      expect(DB.tables).to include(:embeddings)
+      expect(DB.tables(:schema => 'bonanza')).not_to include(:embeddings)
+    end
+  end
+
   it 'deletes from the right schema' do
     Promiscuous::BlackHole::Config.configure do |cfg|
       cfg.schema_generator = -> { @expected_schema_name }

--- a/spec/lib/promiscuous_black_hole_spec.rb
+++ b/spec/lib/promiscuous_black_hole_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Promiscuous::BlackHole do
+  describe '.start' do
+    it 'ensures the embeddings table' do
+      allow(Promiscuous::CLI).to receive(:new).and_return(double(:cli).as_null_object)
+      public_tables = -> { DB.tables(:schema => :public) }
+      DB << 'DROP TABLE public.embeddings'
+
+      expect(public_tables.()).to_not include(:embeddings)
+
+      Promiscuous::BlackHole.start
+      expect(public_tables.()).to include(:embeddings)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ def clear_data
     DB.run("DROP SCHEMA \"#{schema}\" CASCADE")
   end
   DB.drop_table(*DB.tables)
-  Promiscuous::BlackHole::DB.ensure_embeddings_table
+  Promiscuous::BlackHole::EmbeddingsTable.ensure_exists
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This ensures there's one canonical source of all embeddings in the entire database.