### PR TITLE
Handle case where schema doesn't have embedding

### DIFF
--- a/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
+++ b/lib/promiscuous_black_hole/stale_embeddings_destroyer.rb
@@ -27,7 +27,9 @@ module Promiscuous::BlackHole
     private
 
     def fetch_child_tables
-      EmbeddingsTable.where('parent_table = ?', @table_name).map(:child_table)
+      EmbeddingsTable.where('parent_table = ?', @table_name).map(:child_table).select do |table_name|
+        table_name.to_sym.in?(DB.tables)
+      end
     end
 
     def criteria_for(table)


### PR DESCRIPTION
When a schema doesn't have an embedding, we need to still successfully process the message.