### PR TITLE
Lock around transactions to protect against contention

### DIFF
--- a/lib/promiscuous_black_hole/table.rb
+++ b/lib/promiscuous_black_hole/table.rb
@@ -9,23 +9,21 @@ module Promiscuous::BlackHole
     end
 
     def update_schema
-      update_schema! if schema_changed?
+      bust_cache
+
+      create_embedding_metadata if embedded_in_table
+
+      ensure_created
+      ensure_columns
+    end
+
+    def schema_changed?
+      !DB.table_exists?(table_name) || new_attrs.present?
     end
 
     private
 
     attr_reader :table_name, :instance_attrs
-
-    def update_schema!
-      Locker.new(table_name.to_s).with_lock do
-        bust_cache
-
-        create_embedding_metadata if embedded_in_table
-
-        ensure_created
-        ensure_columns
-      end
-    end
 
     def create_embedding_metadata
       attrs = {
@@ -44,10 +42,6 @@ module Promiscuous::BlackHole
 
     def embedded_in_table
       instance_attrs['embedded_in_table']
-    end
-
-    def schema_changed?
-      !DB.table_exists?(table_name) || new_attrs.present?
     end
 
     def ensure_columns

--- a/spec/integration/thread_safety_spec.rb
+++ b/spec/integration/thread_safety_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'handling many concurrent schema changes' do
+  it 'does not fail first when many jobs are writing concurrently' do
+    @error = false
+    use_real_backend { |config| config.error_notifier = proc { @error = true } }
+
+    LockerHelper.delay_after_unlock(0.5) do
+      5.times { PublisherModel.create(:group => 1) }
+      sleep 1
+    end
+
+    expect(@error).to eq(false)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,9 @@ end
 def reload_configuration
   use_real_backend { |c|
     c.subscriber_threads = 2
-    # c.logger = Logger.new(STDOUT).tap {|l| l.level = Logger::INFO }
+    if ENV['LOGGER_LEVEL']
+      c.logger = Logger.new(STDOUT).tap { |l| l.level = ENV['LOGGER_LEVEL'].to_i }
+    end
   }
 
   Promiscuous::BlackHole::Config.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,12 +24,12 @@ Mongoid.configure do |config|
 end
 
 def reload_configuration
-  use_real_backend { |c|
+  use_real_backend do |c|
     c.subscriber_threads = 2
     if ENV['LOGGER_LEVEL']
       c.logger = Logger.new(STDOUT).tap { |l| l.level = ENV['LOGGER_LEVEL'].to_i }
     end
-  }
+  end
 
   Promiscuous::BlackHole::Config.configure do |config|
     config.connection_args = { database: DATABASE }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,10 @@ Mongoid.configure do |config|
 end
 
 def reload_configuration
-  use_real_backend { |c| c.subscriber_threads = 2 }
+  use_real_backend { |c|
+    c.subscriber_threads = 2
+    # c.logger = Logger.new(STDOUT).tap {|l| l.level = Logger::INFO }
+  }
 
   Promiscuous::BlackHole::Config.configure do |config|
     config.connection_args = { database: DATABASE }

--- a/spec/support/locker.rb
+++ b/spec/support/locker.rb
@@ -7,7 +7,6 @@ module LockerHelper
     block.call
     self.block_time = 0
   end
-
 end
 
 Promiscuous::BlackHole::Locker.class_eval do

--- a/spec/support/locker.rb
+++ b/spec/support/locker.rb
@@ -1,0 +1,20 @@
+module LockerHelper
+  mattr_accessor :block_time
+  self.block_time = 0
+
+  def self.delay_after_unlock(time, &block)
+    self.block_time = time
+    block.call
+    self.block_time = 0
+  end
+
+end
+
+Promiscuous::BlackHole::Locker.class_eval do
+  alias_method :orig_with_lock, :with_lock
+
+  def with_lock(&block)
+    orig_with_lock(&block)
+    sleep(LockerHelper.block_time)
+  end
+end


### PR DESCRIPTION
When a schema is updated, we need to lock the table around the whole transaction. The old code released the lock before the transaction committed, which meant that the lock didn't wrap all of the dangerous code. This change pushes responsibility for locking up to the operation class, which can wrap all of the important work in the lock.