### PR TITLE
Handle long tables

### DIFF
--- a/lib/promiscuous_black_hole/db.rb
+++ b/lib/promiscuous_black_hole/db.rb
@@ -37,7 +37,6 @@ module Promiscuous::BlackHole
         yield
       else
         name ||= Config.schema_generator.call
-        p name
         unless DB.schema_exists?(name)
           DB.connection.create_schema(name) rescue nil
         end

--- a/lib/promiscuous_black_hole/db.rb
+++ b/lib/promiscuous_black_hole/db.rb
@@ -5,7 +5,7 @@ module Promiscuous::BlackHole
     end
 
     def self.table_exists?(table, opts = {})
-      DB.tables(opts).include?(table.to_sym)
+      DB.tables(opts).include?(table[0...63].to_sym)
     end
 
     def self.create_table?(table, &block)
@@ -14,6 +14,11 @@ module Promiscuous::BlackHole
 
     def self.search_path
       fetch('show search_path').first[:search_path]
+    end
+
+    def self.max_identifier_length
+      @max_identifier_length ||=
+        fetch('show max_identifier_length').first[:max_identifier_length].to_i - 1
     end
 
     def self.schema_exists?(schema)
@@ -32,6 +37,7 @@ module Promiscuous::BlackHole
         yield
       else
         name ||= Config.schema_generator.call
+        p name
         unless DB.schema_exists?(name)
           DB.connection.create_schema(name) rescue nil
         end

--- a/lib/promiscuous_black_hole/db.rb
+++ b/lib/promiscuous_black_hole/db.rb
@@ -5,7 +5,7 @@ module Promiscuous::BlackHole
     end
 
     def self.table_exists?(table, opts = {})
-      DB.tables(opts).include?(table[0...63].to_sym)
+      DB.tables(opts).include?(table.to_sym)
     end
 
     def self.create_table?(table, &block)

--- a/lib/promiscuous_black_hole/message.rb
+++ b/lib/promiscuous_black_hole/message.rb
@@ -27,7 +27,7 @@ module Promiscuous::BlackHole
         .gsub(/::Base$/, '')
         .gsub(/::/, '_')
         .underscore
-        .pluralize
+        .pluralize[0...DB.max_identifier_length]
     end
 
     def base_type

--- a/lib/promiscuous_black_hole/operation.rb
+++ b/lib/promiscuous_black_hole/operation.rb
@@ -57,6 +57,11 @@ module Promiscuous::BlackHole
       end
 
       Locker.new(message.id).with_lock { in_transaction { persist } }
+    rescue => e
+      puts "*"*88
+      puts e.backtrace
+      puts e
+      raise e
     end
 
     def upsert

--- a/lib/promiscuous_black_hole/operation.rb
+++ b/lib/promiscuous_black_hole/operation.rb
@@ -57,11 +57,6 @@ module Promiscuous::BlackHole
       end
 
       Locker.new(message.id).with_lock { in_transaction { persist } }
-    rescue => e
-      puts "*"*88
-      puts e.backtrace
-      puts e
-      raise e
     end
 
     def upsert

--- a/spec/integration/table_update_spec.rb
+++ b/spec/integration/table_update_spec.rb
@@ -11,6 +11,29 @@ describe Promiscuous::BlackHole do
     expect(DB.table_exists?('publisher_models')).to eq(true)
   end
 
+  it 'handles table names longer than max_identifier_length' do
+    max_identifier_length = DB.fetch('show max_identifier_length').first[:max_identifier_length].to_i
+    long_table_name = "Longname" + "c" * (max_identifier_length)
+    define_constant long_table_name do
+      include Mongoid::Document
+      include Promiscuous::Publisher
+      field :a
+      publish :a
+    end
+
+    model = long_table_name.constantize
+
+    model.create!(:a => 1)
+    model.create!(:a => 2)
+
+    expected_table_name = long_table_name.downcase[0...max_identifier_length - 1]
+
+    sleep 0.2
+
+    expect(DB.table_exists?(expected_table_name)).to eq(true)
+    expect(DB[expected_table_name].select_map(:a)).to eq([1, 2])
+  end
+
   it 'replaces :: with _ in naming the table' do
     expect(DB.table_exists?('hockey_goals')).to eq(false)
 


### PR DESCRIPTION
If a table is longer than postgres is configured to allow, we get strange errors from the sequel gem:
<img width="689" alt="application_errors_-_normcore2__sidecar_-_new_relic" src="https://cloud.githubusercontent.com/assets/1707408/13382749/3ddb7ac0-de4a-11e5-853f-8aeb7b831ef5.png">

The default configuration for postgres is 63 characters for any identifier.
